### PR TITLE
feat(responses): support prompt id with variables

### DIFF
--- a/src/main/java/io/kestra/plugin/openai/Responses.java
+++ b/src/main/java/io/kestra/plugin/openai/Responses.java
@@ -303,6 +303,39 @@ import java.util.Objects;
                             - food
                 """
 
+        ),
+        @Example(
+            full = true,
+            title = "Use a stored prompt template and MCP server with OpenAI's Responses API.",
+            code = """
+                id: prompt_id_demo
+                namespace: company.team
+
+                inputs:
+                  - id: food
+                    type: STRING
+                    defaults: Avocado
+
+                tasks:
+                  - id: generate_structured_response
+                    type: io.kestra.plugin.openai.Responses
+                    apiKey: "{{ secret('OPENAI_API_KEY') }}"
+                    model: gpt-5-mini
+                    input: "Summarize the Pull Requests assigned to me for review."
+                    promptId: "pmpt_XYZ"
+                    promptVariables:
+                      repo: "kestra-io/kestra"
+                      username: "your.name"
+                    tools:
+                      - type: mcp
+                        server_label: GitHub_MCP
+                        server_description: GitHub MCP Server
+                        server_url: "https://api.githubcopilot.com/mcp/"
+                        require_approval: never
+                        authorization: "{{ secret('GITHUB_PERSONAL_ACCESS_TOKEN') }}"
+                        headers:
+                          X-MCP-Readonly: "true"
+                """
         )
     }
 )
@@ -355,6 +388,18 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
     private Property<String> previousResponseId;
 
     @Schema(
+        title = "Reference to a prompt stored in OpenAI Platform (optional)",
+        description = "If provided, the Platform-managed prompt will be used, with `input` added as a user input."
+    )
+    private Property<String> promptId;
+
+    @Schema(
+        title = "Key-value pairs for substitution in the stored prompt (optional)",
+        description = "Ignored unless `promptId` is provided. Values will replace placeholders in the stored prompt."
+    )
+    private Property<Map<String, String>> promptVariables;
+
+    @Schema(
         title = "Reasoning configuration",
         description = "Optional reasoning options map passed to the API."
     )
@@ -394,11 +439,13 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
         ToolChoice renderedToolChoice = runContext.render(this.toolChoice).as(ToolChoice.class).orElse(ToolChoice.AUTO);
         Boolean renderedStore = runContext.render(store).as(Boolean.class).orElse(Boolean.TRUE);
         String renderedPreviousResponseId = runContext.render(this.previousResponseId).as(String.class).orElse(null);
+        String renderedPromptId = runContext.render(this.promptId).as(String.class).orElse(null);
         Integer maxTokens = runContext.render(this.maxOutputTokens).as(Integer.class).orElse(null);
         Double renderedTemperature = runContext.render(this.temperature).as(Double.class).orElse(1.0);
         Double renderedTopP = runContext.render(this.topP).as(Double.class).orElse(1.0);
         Boolean parallelCalls = runContext.render(this.parallelToolCalls).as(Boolean.class).orElse(null);
 
+        Map<String, String> renderedPromptVariables = runContext.render(promptVariables).asMap(String.class, String.class);
         Map<String, String> renderedReasoningMap = runContext.render(reasoning).asMap(String.class, String.class);
         Map<String, Object> renderedTextFormat = runContext.render(text).asMap(String.class, Object.class);
 
@@ -416,6 +463,17 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
             .store(renderedStore)
             .temperature(renderedTemperature)
             .topP(renderedTopP);
+
+        if (renderedPromptId != null) {
+            final var promptBuilder = ResponsePrompt.builder()
+                .id(renderedPromptId);
+            if (renderedPromptVariables != null) {
+                final var renderedVariables = ParametersUtils.OBJECT_MAPPER.convertValue(renderedPromptVariables,
+                    com.openai.models.responses.ResponsePrompt.Variables.class);
+                promptBuilder.variables(renderedVariables);
+            }
+            paramsBuilder.prompt(promptBuilder.build());
+        }
 
         if (renderedTools != null && !renderedTools.isEmpty()) {
             List<Tool> sdkTools = renderedTools.stream()

--- a/src/test/java/io/kestra/plugin/openai/AbstractOpenAITest.java
+++ b/src/test/java/io/kestra/plugin/openai/AbstractOpenAITest.java
@@ -6,6 +6,28 @@ import org.assertj.core.util.Strings;
 @KestraTest
 public class AbstractOpenAITest {
     private static final String OPENAI_API_KEY = System.getenv("OPENAI_API_KEY");
+    /* Create the following Prompt for testing:
+    <system>
+    Respond with the uppercased text that was provided by the user.
+    Example:
+    - User: qwer!
+    - Assistant: QWER!
+    </system>
+     */
+    private static final String PROMPT_ID_TO_UPPER = System.getenv("OPENAI_PROMPT_ID_TO_UPPER");
+    /* Create the following Prompt for testing:
+    <system>
+    Respond with the uppercased text that was provided by the user,
+    appending the user-provided suffix to the output (see below).
+    Example:
+    - User: qwer (provided suffix: ty)
+    - Assistant: QWERty
+    </system>
+    <user>
+    Provided suffix: {{suffix}}
+    </user>
+     */
+    private static final String PROMPT_ID_TO_UPPER_SUFFIX = System.getenv("OPENAI_PROMPT_ID_TO_UPPER_SUFFIX");
 
     protected static boolean canNotBeEnabled() {
         return Strings.isNullOrEmpty(getApiKey());
@@ -13,5 +35,21 @@ public class AbstractOpenAITest {
 
     protected static String getApiKey() {
         return OPENAI_API_KEY;
+    }
+
+    protected static boolean canNotTestPromptId() {
+        return Strings.isNullOrEmpty(getPromptIdToUpper());
+    }
+
+    protected static String getPromptIdToUpper() {
+        return PROMPT_ID_TO_UPPER;
+    }
+
+    protected static boolean canNotTestPromptIdVariables() {
+        return Strings.isNullOrEmpty(getPromptIdToUpperSuffix());
+    }
+
+    protected static String getPromptIdToUpperSuffix() {
+        return PROMPT_ID_TO_UPPER_SUFFIX;
     }
 }

--- a/src/test/java/io/kestra/plugin/openai/ResponsesTest.java
+++ b/src/test/java/io/kestra/plugin/openai/ResponsesTest.java
@@ -51,6 +51,61 @@ public class ResponsesTest extends AbstractOpenAITest {
     }
 
     @Test
+    @DisabledIf(
+        value = "canNotTestPromptId",
+        disabledReason = "Needs ID of an OpenAI Platform-stored Prompt without Prompt Variables"
+    )
+    void testPromptById() throws Exception {
+        RunContext runContext = runContextFactory.of();
+
+        Responses task = Responses.builder()
+            .id("test-task")
+            .type(Responses.class.getName())
+            .apiKey(Property.ofValue(getApiKey()))
+            .clientTimeout(30)
+            .model(Property.ofValue("gpt-5-nano"))
+            .promptId(Property.ofValue(getPromptIdToUpper()))
+            .input(Property.ofValue("asdf")) // not a typo: prompt by ID tells model to return uppercase of input
+            .build();
+
+        Responses.Output output = task.run(runContext);
+
+        assertNotNull(output);
+        assertNotNull(output.getResponseId());
+        assertNotNull(output.getOutputText());
+        assertThat(output.getOutputText(), containsString("ASDF"));
+        assertNotNull(output.getRawResponse());
+    }
+
+    @Test
+    @DisabledIf(
+        value = "canNotTestPromptIdVariables",
+        disabledReason = "Needs ID of an OpenAI Platform-stored Prompt with Prompt Variable 'suffix'"
+    )
+    void testPromptByIdWithVariables() throws Exception {
+        RunContext runContext = runContextFactory.of();
+
+        Responses task = Responses.builder()
+            .id("test-task")
+            .type(Responses.class.getName())
+            .apiKey(Property.ofValue(getApiKey()))
+            .clientTimeout(30)
+            .model(Property.ofValue("gpt-5-nano"))
+            .promptId(Property.ofValue(getPromptIdToUpperSuffix()))
+            .input(Property.ofValue("auto"))
+            .promptVariables(Property.ofValue(Map.of("suffix", "mation")))
+            .build();
+
+        Responses.Output output = task.run(runContext);
+
+        assertNotNull(output);
+        assertNotNull(output.getResponseId());
+        assertNotNull(output.getOutputText());
+        assertThat(output.getOutputText(), containsString("AUTOmation"));
+        assertNotNull(output.getRawResponse());
+    }
+
+    @Test
     void testWebSearchTool() throws Exception {
         RunContext runContext = runContextFactory.of();
 

--- a/src/test/java/io/kestra/plugin/openai/ResponsesTest.java
+++ b/src/test/java/io/kestra/plugin/openai/ResponsesTest.java
@@ -157,7 +157,7 @@ public class ResponsesTest extends AbstractOpenAITest {
         Map<String, Object> functionTool = Map.of(
             "type", "function",
             "name", "respond_to_review",
-            "description", "Analyze the sentiment of the provided text in one word",
+            "description", "Create a suggested reply to the provided customer review.",
             "strict", true,
             "parameters", toolParameters
         );
@@ -176,10 +176,10 @@ public class ResponsesTest extends AbstractOpenAITest {
 
         assertNotNull(output);
         assertNotNull(output.getOutputText());
-        assertThat(output.getOutputText(), anyOf(
-            containsStringIgnoringCase("happy"),
-            containsStringIgnoringCase("enjoy"),
-            containsStringIgnoringCase("positive")
+        assertThat(output.getOutputText(), allOf(
+            containsStringIgnoringCase("reply_later"),
+            containsStringIgnoringCase("response_urgency"),
+            containsStringIgnoringCase("response_text")
         ));
     }
 }


### PR DESCRIPTION
This PR implements Prompt ID support with optional Prompt Variables – see [OpenAI Docs](https://developers.openai.com/api/docs/guides/prompting#create-a-prompt) for more info. For simplicity, I will refer to prompts stored in the OpenAI Platform as 'stored prompts'.

By leveraging stored prompts, developers can use the OpenAI Platform as the source of truth and iterate on prompts without needing to update the Kestra flow.

See the included documentation update for a flow example. This example additionally includes how to use a custom MCP server with the Responses task.
This change was QA'd with the updated Tests as well as in a running Kestra instance.

---

### Test Logs

First test run had 1 failure unrelated to the code touched in this PR:
```
> Task :test
[...]
    java.lang.AssertionError: 
    Expected: (a string containing "happy" ignoring case or a string containing "enjoy" ignoring case or a string containing "positive" ignoring case)
         but: was "{"response_urgency":"reply_later","response_text":"Thank you so much for your enthusiasm! We're thrilled to hear that you love the new feature. Your support encourages us to keep improving. If you have any feedback or suggestions, we’d love to hear them!"}"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at io.kestra.plugin.openai.ResponsesTest.testFunctionTool(ResponsesTest.java:178)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at io.micronaut.test.extensions.junit5.MicronautJunit5Extension$2.proceed(MicronautJunit5Extension.java:142)
        at io.micronaut.test.extensions.AbstractMicronautExtension.interceptEach(AbstractMicronautExtension.java:162)
        at io.micronaut.test.extensions.AbstractMicronautExtension.interceptTest(AbstractMicronautExtension.java:119)
        at io.micronaut.test.extensions.junit5.MicronautJunit5Extension.interceptTestMethod(MicronautJunit5Extension.java:129)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
[...]
5 tests completed, 1 failed
> Task :test FAILED
[...]
```

After fixing the bad test input data (see second commit), the test passed:
```
> Task :test
  io.kestra.plugin.openai.ResponsesTest  √ testFunctionTool() (5.3s)
  1 passing (19.2s)
```

### Updated Testing Instructions

To test the stored prompts feature, create two new stored prompts in your OpenAI account, using the prompt text from `AbstractOpenAITest.java`. Here is how it should look:

<img width="1909" height="1033" alt="Screenshot of OpenAI Platform Prompt editor without a prompt variable" src="https://github.com/user-attachments/assets/ee21cfc2-2c5c-4d40-9548-2ec9c2d5da9b" />

and the second one:

<img width="1921" height="1031" alt="Screenshot of OpenAI Platform Prompt editor with a prompt variable" src="https://github.com/user-attachments/assets/d55764ae-ccce-4b78-aa18-15035be4478a" />

Then, add the prompt IDs as environment variables in the Test Runner config.

- env `OPENAI_PROMPT_ID_TO_UPPER` for the stored prompt without variable
- env `OPENAI_PROMPT_ID_TO_UPPER_SUFFIX` for the stored prompt with variable

The tests will be skipped if the variables are not set.

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
