### PR TITLE
feat: add prompt caching support

### DIFF
--- a/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
@@ -219,6 +219,15 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
     )
     private Property<String> jsonResponseSchema;
 
+    @Schema(
+        title = "Enable prompt caching",
+        description = """
+            When true, enables OpenAI prompt caching to reduce latency and cost for \
+            repeated prefixes. See the \
+            [prompt caching docs](https://platform.openai.com/docs/guides/prompt-caching)."""
+    )
+    private Property<Boolean> promptCaching;
+
     @Override
     public ChatCompletion.Output run(RunContext runContext) throws Exception {
         OpenAIClient client = this.openAIClient(runContext);
@@ -272,6 +281,11 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
 
         if (rJsonResponseSchema != null) {
             builder.responseFormat(buildOpenAIResponseFormat(rJsonResponseSchema));
+        }
+
+        var rPromptCaching = runContext.render(this.promptCaching).as(Boolean.class).orElse(false);
+        if (Boolean.TRUE.equals(rPromptCaching)) {
+            builder.promptCacheRetention(ChatCompletionCreateParams.PromptCacheRetention._24H);
         }
 
         String renderedFunctionCall = this.functionCall != null ? runContext.render(this.functionCall).as(String.class).orElse("auto") : "auto";
@@ -333,9 +347,13 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
             .create(chatCompletionCreateParams);
 
         if (chatCompletionResult.usage().isPresent()) {
-            runContext.metric(Counter.of("usage.prompt.tokens", chatCompletionResult.usage().get().promptTokens()));
-            runContext.metric(Counter.of("usage.completion.tokens", chatCompletionResult.usage().get().completionTokens()));
-            runContext.metric(Counter.of("usage.total.tokens", chatCompletionResult.usage().get().totalTokens()));
+            var usage = chatCompletionResult.usage().get();
+            runContext.metric(Counter.of("usage.prompt.tokens", usage.promptTokens()));
+            runContext.metric(Counter.of("usage.completion.tokens", usage.completionTokens()));
+            runContext.metric(Counter.of("usage.total.tokens", usage.totalTokens()));
+            usage.promptTokensDetails()
+                .flatMap(CompletionUsage.PromptTokensDetails::cachedTokens)
+                .ifPresent(cached -> runContext.metric(Counter.of("usage.prompt.cached_tokens", cached)));
         }
         return ChatCompletion.Output.builder()
             .id(chatCompletionResult.id())

--- a/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
@@ -222,8 +222,8 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
     @Schema(
         title = "Enable prompt caching",
         description = """
-            When true, enables OpenAI prompt caching to reduce latency and cost for \
-            repeated prefixes. See the \
+            When true, enables OpenAI prompt caching to reduce latency and cost for
+            repeated prefixes. See the
             [prompt caching docs](https://platform.openai.com/docs/guides/prompt-caching)."""
     )
     private Property<Boolean> promptCaching;

--- a/src/main/java/io/kestra/plugin/openai/Responses.java
+++ b/src/main/java/io/kestra/plugin/openai/Responses.java
@@ -431,6 +431,15 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
     )
     private Property<Boolean> parallelToolCalls;
 
+    @Schema(
+        title = "Enable prompt caching",
+        description = """
+            When true, enables OpenAI prompt caching to reduce latency and cost for \
+            repeated prefixes. See the \
+            [prompt caching docs](https://platform.openai.com/docs/guides/prompt-caching)."""
+    )
+    private Property<Boolean> promptCaching;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         OpenAIClient client = this.openAIClient(runContext);
@@ -512,14 +521,21 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
             paramsBuilder.text(textFormat);
         }
 
+        var rPromptCaching = runContext.render(this.promptCaching).as(Boolean.class).orElse(false);
+        if (Boolean.TRUE.equals(rPromptCaching)) {
+            paramsBuilder.promptCacheRetention(ResponseCreateParams.PromptCacheRetention._24H);
+        }
+
         ResponseCreateParams params = paramsBuilder.build();
 
         Response outputResponse = client.responses().create(params);
 
         if (outputResponse.usage().isPresent()) {
-            runContext.metric(Counter.of("usage.prompt.tokens", outputResponse.usage().get().inputTokens()));
-            runContext.metric(Counter.of("usage.completion.tokens", outputResponse.usage().get().outputTokens()));
-            runContext.metric(Counter.of("usage.total.tokens", outputResponse.usage().get().totalTokens()));
+            var usage = outputResponse.usage().get();
+            runContext.metric(Counter.of("usage.prompt.tokens", usage.inputTokens()));
+            runContext.metric(Counter.of("usage.completion.tokens", usage.outputTokens()));
+            runContext.metric(Counter.of("usage.total.tokens", usage.totalTokens()));
+            runContext.metric(Counter.of("usage.prompt.cached_tokens", usage.inputTokensDetails().cachedTokens()));
         }
 
         List<String> sources = outputResponse.output().stream()

--- a/src/main/java/io/kestra/plugin/openai/Responses.java
+++ b/src/main/java/io/kestra/plugin/openai/Responses.java
@@ -434,8 +434,8 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
     @Schema(
         title = "Enable prompt caching",
         description = """
-            When true, enables OpenAI prompt caching to reduce latency and cost for \
-            repeated prefixes. See the \
+            When true, enables OpenAI prompt caching to reduce latency and cost for
+            repeated prefixes. See the
             [prompt caching docs](https://platform.openai.com/docs/guides/prompt-caching)."""
     )
     private Property<Boolean> promptCaching;


### PR DESCRIPTION
## Summary
- Add a `promptCaching` boolean property to **ChatCompletion** and **Responses** tasks
- When enabled, sets 24-hour prompt cache retention via the OpenAI API, reducing latency and cost for repeated prompt prefixes
- Emits a `usage.prompt.cached_tokens` metric when cached tokens are reported

## Test plan
- [ ] Build passes (`./gradlew shadowJar`)
- [ ] Verify `promptCaching: true` sets retention on the SDK builder
- [ ] Verify `usage.prompt.cached_tokens` metric is emitted when OpenAI reports cached usage
- [ ] Verify default behavior (no property set) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)