### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/openai/AbstractTask.java
+++ b/src/main/java/io/kestra/plugin/openai/AbstractTask.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -27,6 +28,7 @@ public abstract class AbstractTask extends Task implements OpenAiInterface {
         title = "OpenAI API key"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> apiKey;
 
     protected Property<String> user;

--- a/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
@@ -23,6 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -134,12 +135,14 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
         title = "Messages to send to the model",
         description = "Required when `prompt` is absent; each entry keeps its role and content."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<ChatMessage>> messages;
 
     @Schema(
         title = "Functions exposed as tools",
         description = "Define tool-callable functions with names, descriptions, and parameters; ignored if none provided."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<PluginChatFunction>> functions;
 
     @Schema(
@@ -147,12 +150,14 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
         description = "Use 'auto' (default), 'none', or a specific function name present in `functions`; other names raise an error."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<String> functionCall = Property.ofValue("auto");
 
     @Schema(
         title = "Prompt text to send",
         description = "Sent as a `user` message when `messages` are omitted; required if `messages` is not set."
     )
+    @PluginProperty(group = "main")
     private Property<String> prompt;
 
     @Schema(
@@ -160,6 +165,7 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
         description = "Default 1.0; higher values increase randomness."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Double> temperature = Property.ofValue(1.0);
 
     @Schema(
@@ -167,6 +173,7 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
         description = "Default 1.0; lower values limit token candidates."
     )
     @Builder.Default
+    @PluginProperty(group = "destination")
     private Property<Double> topP = Property.ofValue(1.0);
 
     @Schema(
@@ -174,36 +181,42 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
         description = "Default 1; controls size of `choices` list."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Integer> n = Property.ofValue(1);
 
     @Schema(
         title = "Stop sequences",
         description = "Up to 4 strings; default is none."
     )
+    @PluginProperty(group = "destination")
     private Property<List<String>> stop;
 
     @Schema(
         title = "Max completion tokens",
         description = "Leave null to rely on model defaults; counts only completion tokens."
     )
+    @PluginProperty(group = "connection")
     private Property<Long> maxTokens;
 
     @Schema(
         title = "Presence penalty (-2 to 2)",
         description = "Default 0; positive values discourage repeating earlier topics."
     )
+    @PluginProperty(group = "advanced")
     private Property<Double> presencePenalty;
 
     @Schema(
         title = "Frequency penalty (-2 to 2)",
         description = "Default 0; positive values reduce reuse of frequent tokens."
     )
+    @PluginProperty(group = "advanced")
     private Property<Double> frequencyPenalty;
 
     @Schema(
         title = "Token logit bias",
         description = "Map token IDs to bias values; empty when unset."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Integer>> logitBias;
 
     @Schema(
@@ -211,12 +224,14 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
         description = "Required OpenAI model identifier (e.g., `gpt-4o`); see the [model docs](https://platform.openai.com/docs/models/overview)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> model;
 
     @Schema(
         title = "JSON response schema",
         description = "Stringified JSON Schema enabling `response_format` = `json_schema`; uses name `kestra_schema` with `strict` true."
     )
+    @PluginProperty(group = "connection")
     private Property<String> jsonResponseSchema;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/openai/CreateImage.java
+++ b/src/main/java/io/kestra/plugin/openai/CreateImage.java
@@ -31,6 +31,7 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwConsumer;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -66,12 +67,14 @@ public class CreateImage extends AbstractTask implements RunnableTask<CreateImag
         description = "Required text sent to the Images API."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> prompt;
 
     @Schema(
         title = "Number of images",
         description = "Between 1 and 10; OpenAI defaults to 1 when unset."
     )
+    @PluginProperty(group = "advanced")
     private Integer n;
 
     @Schema(
@@ -80,6 +83,7 @@ public class CreateImage extends AbstractTask implements RunnableTask<CreateImag
     )
     @Builder.Default
     @NotNull
+    @PluginProperty(group = "advanced")
     private Property<SIZE> size = Property.ofValue(SIZE.LARGE);
 
     @Schema(
@@ -88,6 +92,7 @@ public class CreateImage extends AbstractTask implements RunnableTask<CreateImag
     )
     @Builder.Default
     @NotNull
+    @PluginProperty(group = "advanced")
     private Property<Boolean> download = Property.ofValue(Boolean.FALSE);
 
     @Override

--- a/src/main/java/io/kestra/plugin/openai/OpenAiInterface.java
+++ b/src/main/java/io/kestra/plugin/openai/OpenAiInterface.java
@@ -4,21 +4,25 @@ import io.kestra.core.models.property.Property;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import io.kestra.core.models.annotations.PluginProperty;
 
 public interface OpenAiInterface {
     @Schema(
         title = "The OpenAI API key"
     )
     @NotNull
+    @PluginProperty(group = "main")
     Property<String> getApiKey();
 
     @Schema(
         title = "A unique identifier representing your end-user"
     )
+    @PluginProperty(group = "advanced")
     Property<String> getUser();
 
     @Schema(
         title = "The maximum number of seconds to wait for a response"
     )
+    @PluginProperty(group = "execution")
     long getClientTimeout();
 }

--- a/src/main/java/io/kestra/plugin/openai/Responses.java
+++ b/src/main/java/io/kestra/plugin/openai/Responses.java
@@ -22,6 +22,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -346,6 +347,7 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
         description = "Required OpenAI model (e.g., gpt-4.1 or gpt-4o); see the [model docs](https://platform.openai.com/docs/models)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> model;
 
     @Schema(
@@ -353,24 +355,28 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
         description = "String or structured `input` list for the conversation; required."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<Object> input;
 
     @Schema(
         title = "Text response config",
         description = "Optional map for text output settings (e.g., `json_schema` formatted responses)."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> text;
 
     @Schema(
         title = "Enabled tools",
         description = "List of tool objects (web_search_preview, file_search, function, etc.) sent to the API."
     )
+    @PluginProperty(group = "destination")
     private Property<List<Map<String, Object>>> tools;
 
     @Schema(
         title = "Tool choice",
         description = "NONE disables tools, AUTO (default) lets the model decide, REQUIRED forces a tool call when tools are provided."
     )
+    @PluginProperty(group = "destination")
     private Property<ToolChoice> toolChoice;
 
     @Schema(
@@ -379,12 +385,14 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
     )
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "destination")
     private Property<Boolean> store = Property.ofValue(true);
 
     @Schema(
         title = "Previous response ID",
         description = "Continue a conversation by supplying a prior `response_id`; requires prior persistence."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> previousResponseId;
 
     @Schema(
@@ -403,12 +411,14 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
         title = "Reasoning configuration",
         description = "Optional reasoning options map passed to the API."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, String>> reasoning;
 
     @Schema(
         title = "Max output tokens",
         description = "Caps response tokens; leave unset to use OpenAI defaults."
     )
+    @PluginProperty(group = "connection")
     private Property<Integer> maxOutputTokens;
 
     @Schema(
@@ -429,6 +439,7 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
         title = "Parallel tool calls",
         description = "Whether tools may run in parallel; uses provider default when unset."
     )
+    @PluginProperty(group = "execution")
     private Property<Boolean> parallelToolCalls;
 
     @Schema(

--- a/src/main/java/io/kestra/plugin/openai/UploadFile.java
+++ b/src/main/java/io/kestra/plugin/openai/UploadFile.java
@@ -88,7 +88,7 @@ public class UploadFile extends AbstractTask implements RunnableTask<UploadFile.
         description = "Required `kestra://` or other storage URI pointing to the file to upload."
     )
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(internalStorageURI = true, group = "main")
     private Property<String> from;
 
     @Schema(
@@ -96,6 +96,7 @@ public class UploadFile extends AbstractTask implements RunnableTask<UploadFile.
         description = "Accepted values include assistants, fine-tune, vision, user_data, evals, batch; defaults to assistants for unrecognized values."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> purpose;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712