### PR TITLE
fix: only send top_p when set

### DIFF
--- a/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/openai/ChatCompletion.java
@@ -170,11 +170,10 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
 
     @Schema(
         title = "Nucleus sampling top_p",
-        description = "Default 1.0; lower values limit token candidates."
+        description = "Lower values limit token candidates. Omit to let OpenAI apply its server-side default. Must be omitted for reasoning models (e.g., gpt-5.2+, gpt-5.4) which reject `top_p`."
     )
-    @Builder.Default
     @PluginProperty(group = "destination")
-    private Property<Double> topP = Property.ofValue(1.0);
+    private Property<Double> topP;
 
     @Schema(
         title = "Number of choices",
@@ -288,11 +287,15 @@ public class ChatCompletion extends AbstractTask implements RunnableTask<ChatCom
             .messages(messages)
             .model(model)
             .temperature(this.temperature == null ? null : runContext.render(this.temperature).as(Double.class).orElse(1.0))
-            .topP(this.topP == null ? null : runContext.render(this.topP).as(Double.class).orElse(1.0))
             .n(runContext.render(this.n).as(Integer.class).orElse(1))
             .maxCompletionTokens(this.maxTokens == null ? null : runContext.render(this.maxTokens).as(Long.class).orElseThrow())
             .presencePenalty(this.presencePenalty == null ? null : runContext.render(this.presencePenalty).as(Double.class).orElseThrow())
             .frequencyPenalty(this.frequencyPenalty == null ? null : runContext.render(this.frequencyPenalty).as(Double.class).orElseThrow());
+
+        Double rTopP = this.topP == null ? null : runContext.render(this.topP).as(Double.class).orElse(null);
+        if (rTopP != null) {
+            builder.topP(rTopP);
+        }
 
         if (rJsonResponseSchema != null) {
             builder.responseFormat(buildOpenAIResponseFormat(rJsonResponseSchema));

--- a/src/main/java/io/kestra/plugin/openai/Responses.java
+++ b/src/main/java/io/kestra/plugin/openai/Responses.java
@@ -430,10 +430,9 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
 
     @Schema(
         title = "Top-p nucleus sampling (0-1)",
-        description = "Default 1.0; lower values limit candidate tokens."
+        description = "Lower values limit candidate tokens. Omit to let OpenAI apply its server-side default. Must be omitted for reasoning models (e.g., gpt-5.2+, gpt-5.4) which reject `top_p`."
     )
-    @Builder.Default
-    private Property<@Max(1) Double> topP = Property.ofValue(1.0);
+    private Property<@Max(1) Double> topP;
 
     @Schema(
         title = "Parallel tool calls",
@@ -462,7 +461,7 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
         String renderedPromptId = runContext.render(this.promptId).as(String.class).orElse(null);
         Integer maxTokens = runContext.render(this.maxOutputTokens).as(Integer.class).orElse(null);
         Double renderedTemperature = runContext.render(this.temperature).as(Double.class).orElse(1.0);
-        Double renderedTopP = runContext.render(this.topP).as(Double.class).orElse(1.0);
+        Double renderedTopP = runContext.render(this.topP).as(Double.class).orElse(null);
         Boolean parallelCalls = runContext.render(this.parallelToolCalls).as(Boolean.class).orElse(null);
 
         Map<String, String> renderedPromptVariables = runContext.render(promptVariables).asMap(String.class, String.class);
@@ -481,8 +480,11 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
             .input(modelInput)
             .model(modelName)
             .store(renderedStore)
-            .temperature(renderedTemperature)
-            .topP(renderedTopP);
+            .temperature(renderedTemperature);
+
+        if (renderedTopP != null) {
+            paramsBuilder.topP(renderedTopP);
+        }
 
         if (renderedPromptId != null) {
             final var promptBuilder = ResponsePrompt.builder()


### PR DESCRIPTION
Only send `top_p` to OpenAI when the user has explicitly set it. The previous behavior defaulted `topP` to `1.0` and always passed it to the SDK request, which caused reasoning models (gpt-5.2+, gpt-5.4) to reject the request with a 400 since they do not accept `top_p`.

## Changes
- `Responses`: drop the hardcoded `1.0` default on `topP` and only call `paramsBuilder.topP(...)` when the rendered value is non-null.
- `ChatCompletion`: same treatment, removed the always-on `.topP(...)` from the chained builder.
- `@Schema` description on `topP` updated in both tasks: omit to let OpenAI apply its server-side default, and must be omitted for reasoning models.

Backwards compatible: existing flows that explicitly set `topP` continue to work unchanged. Flows that did not set it previously got a silent `1.0`; now they let OpenAI apply its own default, which unblocks reasoning models.

## Test plan
- [x] `./gradlew clean compileJava compileTestJava` passes.
- [x] `./gradlew test` passes (live-API tests skipped without `OPENAI_API_KEY`, as in CI without secrets).
- [ ] Run a flow against a reasoning model (e.g. `gpt-5.2`) without setting `topP` and confirm the 400 is gone.
- [ ] Run a flow that explicitly sets `topP` and confirm the value is still sent.

Fixes #132