### PR TITLE
fix(responses): use GA web_search tool instead of legacy web_search_preview

### DIFF
--- a/src/main/java/io/kestra/plugin/openai/Responses.java
+++ b/src/main/java/io/kestra/plugin/openai/Responses.java
@@ -79,7 +79,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     input: "{{ inputs.prompt }}"
                     toolChoice: REQUIRED
                     tools:
-                      - type: web_search_preview
+                      - type: web_search
 
                   - id: log
                     type: io.kestra.plugin.core.log.Log
@@ -106,7 +106,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     input: "{{ inputs.prompt }}"
                     toolChoice: REQUIRED
                     tools:
-                      - type: web_search_preview
+                      - type: web_search
                         search_context_size: low  # optional; low, medium, high
                         user_location:
                           type: approximate # OpenAI doesn't provide other types atm, and it cannot be omitted
@@ -367,7 +367,7 @@ public class Responses extends AbstractTask implements RunnableTask<Responses.Ou
 
     @Schema(
         title = "Enabled tools",
-        description = "List of tool objects (web_search_preview, file_search, function, etc.) sent to the API."
+        description = "List of tool objects (web_search, file_search, function, etc.) sent to the API."
     )
     @PluginProperty(group = "destination")
     private Property<List<Map<String, Object>>> tools;

--- a/src/test/java/io/kestra/plugin/openai/ResponsesTest.java
+++ b/src/test/java/io/kestra/plugin/openai/ResponsesTest.java
@@ -112,7 +112,7 @@ public class ResponsesTest extends AbstractOpenAITest {
         RunContext runContext = runContextFactory.of();
 
         Map<String, Object> webSearchTool = Map.of(
-            "type", "web_search_preview",
+            "type", "web_search",
             "search_context_size", "low",
             "user_location", Map.of("type", "approximate", "city", "Berlin", "region", "Berlin", "country", "DE")
         );


### PR DESCRIPTION
## Problem

`ResponsesTest.testWebSearchTool()` fails intermittently on `main` (e.g. [run 27396980491](https://github.com/kestra-io/plugin-openai/actions/runs/27396980491)) with:

```
400: Unknown parameter: 'tools[0].search_content_types'
```

## Root cause

This is **not** a plugin bug — it's a server-side issue with OpenAI's legacy `web_search_preview` tool:

- Reproducing the exact deserialize→serialize path the plugin uses (`JacksonMapper` → SDK `Tool` union → SDK request mapper) with both openai-java `4.35.0` and the dependabot-bumped `4.39.1` shows the request body the plugin sends is clean and contains **no** `search_content_types`.
- `search_content_types` only exists on the SDK's legacy `WebSearchPreviewTool`, and per OpenAI's docs it's a **GA `web_search`-only** parameter.
- Run history confirms intermittency (06-10 ✓, 06-11 ✗, 06-11 ✓, 06-12 ✗), all failing with the identical error — i.e. some OpenAI backends reject the legacy preview tool citing a GA-only field the request never sent.

## Fix

Migrate to the GA `web_search` tool, which OpenAI recommends for new integrations and which is supported on the gpt-4.1 series. Verified that `type: web_search` deserializes to the GA `WebSearchTool` (no `search_content_types` field) with a clean wire body.

- `ResponsesTest.java` — `testWebSearchTool()` tool type
- `Responses.java` — two `@Example` flows + the `tools` property description

`compileTestJava` passes; the live test runs in CI where the API key is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)